### PR TITLE
Add support for devlink DPIPE tables

### DIFF
--- a/client.go
+++ b/client.go
@@ -39,9 +39,9 @@ func (c *Client) Ports() ([]*Port, error) {
 	return c.c.Ports()
 }
 
-// DpipeTables retrieves all devlink DPIPE tables attached to specified device on this system.
-func (c *Client) DpipeTables(dev *Device) ([]*DpipeTable, error) {
-	return c.c.DpipeTables(dev)
+// DPIPETables retrieves all devlink DPIPE tables attached to specified device on this system.
+func (c *Client) DPIPETables(dev *Device) ([]*DPIPETable, error) {
+	return c.c.DPIPETables(dev)
 }
 
 // An osClient is the operating system-specific implementation of Client.
@@ -49,7 +49,7 @@ type osClient interface {
 	io.Closer
 	Devices() ([]*Device, error)
 	Ports() ([]*Port, error)
-	DpipeTables(*Device) ([]*DpipeTable, error)
+	DPIPETables(*Device) ([]*DPIPETable, error)
 }
 
 // A Device is a devlink device.
@@ -80,8 +80,10 @@ type Port struct {
 	Name   string
 }
 
-// A DpipeTable is a devlink DPIPE table
-type DpipeTable struct {
+// A DPIPETable is a devlink pipeline debugging (DPIPE) table.
+// For more information on DPIPE, see:
+// https://github.com/Mellanox/mlxsw/wiki/Pipeline-Debugging-(DPIPE)
+type DPIPETable struct {
 	Bus             string
 	Device          string
 	Name            string

--- a/client.go
+++ b/client.go
@@ -39,11 +39,17 @@ func (c *Client) Ports() ([]*Port, error) {
 	return c.c.Ports()
 }
 
+// DpipeTables retrieves all devlink DPIPE tables attached to specified device on this system.
+func (c *Client) DpipeTables(dev *Device) ([]*DpipeTable, error) {
+	return c.c.DpipeTables(dev)
+}
+
 // An osClient is the operating system-specific implementation of Client.
 type osClient interface {
 	io.Closer
 	Devices() ([]*Device, error)
 	Ports() ([]*Port, error)
+	DpipeTables(*Device) ([]*DpipeTable, error)
 }
 
 // A Device is a devlink device.
@@ -72,4 +78,13 @@ type Port struct {
 	Port   int
 	Type   PortType
 	Name   string
+}
+
+// A DpipeTable is a devlink DPIPE table
+type DpipeTable struct {
+	Bus             string
+	Device          string
+	Name            string
+	Size            uint64
+	CountersEnabled bool
 }

--- a/client_linux.go
+++ b/client_linux.go
@@ -45,7 +45,7 @@ func (c *client) Close() error { return c.c.Close() }
 
 // Devices implements osClient.
 func (c *client) Devices() ([]*Device, error) {
-	msgs, err := c.execute(unix.DEVLINK_CMD_GET, netlink.Dump)
+	msgs, err := c.execute(unix.DEVLINK_CMD_GET, netlink.Dump, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -55,7 +55,7 @@ func (c *client) Devices() ([]*Device, error) {
 
 // Ports implements osClient.
 func (c *client) Ports() ([]*Port, error) {
-	msgs, err := c.execute(unix.DEVLINK_CMD_PORT_GET, netlink.Dump)
+	msgs, err := c.execute(unix.DEVLINK_CMD_PORT_GET, netlink.Dump, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -65,13 +65,14 @@ func (c *client) Ports() ([]*Port, error) {
 
 // execute executes the specified command with additional header flags. The
 // netlink.Request header flag is automatically set.
-func (c *client) execute(cmd uint8, flags netlink.HeaderFlags) ([]genetlink.Message, error) {
+func (c *client) execute(cmd uint8, flags netlink.HeaderFlags, data []byte) ([]genetlink.Message, error) {
 	return c.c.Execute(
 		genetlink.Message{
 			Header: genetlink.Header{
 				Command: cmd,
 				Version: unix.DEVLINK_GENL_VERSION,
 			},
+			Data: data,
 		},
 		// Always pass the genetlink family ID and request flag.
 		c.family.ID,

--- a/client_linux.go
+++ b/client_linux.go
@@ -68,7 +68,7 @@ func (c *client) Ports() ([]*Port, error) {
 // DpipeTables implements osClient.
 func (c *client) DpipeTables(dev *Device) ([]*DpipeTable, error) {
 	if dev == nil {
-		return nil, fmt.Errorf("Invalid argument")
+		return nil, fmt.Errorf("invalid argument")
 	}
 	encoder := netlink.NewAttributeEncoder()
 	encoder.String(unix.DEVLINK_ATTR_BUS_NAME, dev.Bus)

--- a/client_linux.go
+++ b/client_linux.go
@@ -191,6 +191,7 @@ func parseDPIPETables(msgs []genetlink.Message) ([]*DPIPETable, error) {
 				dev = ad.String()
 			case unix.DEVLINK_ATTR_DPIPE_TABLES:
 				// Netlink array of DPIPE tables.
+				// Errors while parsing are propagated up to top-level ad.Err check.
 				ad.Nested(func(nad *netlink.AttributeDecoder) error {
 					for nad.Next() {
 						t := parseDPIPETable(nad)
@@ -202,6 +203,9 @@ func parseDPIPETables(msgs []genetlink.Message) ([]*DPIPETable, error) {
 				})
 			}
 
+		}
+		if err := ad.Err(); err != nil {
+			return nil, err
 		}
 	}
 	return ts, nil

--- a/client_linux.go
+++ b/client_linux.go
@@ -65,8 +65,8 @@ func (c *client) Ports() ([]*Port, error) {
 	return parsePorts(msgs)
 }
 
-// DpipeTables implements osClient.
-func (c *client) DpipeTables(dev *Device) ([]*DpipeTable, error) {
+// DPIPETables implements osClient.
+func (c *client) DPIPETables(dev *Device) ([]*DPIPETable, error) {
 	if dev == nil {
 		return nil, fmt.Errorf("invalid argument")
 	}
@@ -83,7 +83,7 @@ func (c *client) DpipeTables(dev *Device) ([]*DpipeTable, error) {
 		return nil, err
 	}
 
-	return parseDpipeTables(msgs)
+	return parseDPIPETables(msgs)
 }
 
 // execute executes the specified command with additional header flags. The
@@ -164,15 +164,15 @@ func parsePorts(msgs []genetlink.Message) ([]*Port, error) {
 	return ps, nil
 }
 
-// parseDpipeTables parses DPIPE tables from a slice of generic netlink messages.
-func parseDpipeTables(msgs []genetlink.Message) ([]*DpipeTable, error) {
+// parseDPIPETables parses DPIPE tables from a slice of generic netlink messages.
+func parseDPIPETables(msgs []genetlink.Message) ([]*DPIPETable, error) {
 	var bus, dev string
 	if len(msgs) == 0 {
 		// No devlink response found.
 		return nil, nil
 	}
 
-	ts := make([]*DpipeTable, 0, len(msgs))
+	ts := make([]*DPIPETable, 0, len(msgs))
 	for _, m := range msgs {
 		ad, err := netlink.NewAttributeDecoder(m.Data)
 		if err != nil {
@@ -198,7 +198,7 @@ func parseDpipeTables(msgs []genetlink.Message) ([]*DpipeTable, error) {
 						if err != nil {
 							continue
 						}
-						var t DpipeTable
+						var t DPIPETable
 						t.Bus = bus
 						t.Device = dev
 						for adTable.Next() {

--- a/client_linux.go
+++ b/client_linux.go
@@ -70,10 +70,10 @@ func (c *client) DPIPETables(dev *Device) ([]*DPIPETable, error) {
 	if dev == nil {
 		return nil, fmt.Errorf("invalid argument")
 	}
-	encoder := netlink.NewAttributeEncoder()
-	encoder.String(unix.DEVLINK_ATTR_BUS_NAME, dev.Bus)
-	encoder.String(unix.DEVLINK_ATTR_DEV_NAME, dev.Device)
-	data, err := encoder.Encode()
+	ae := netlink.NewAttributeEncoder()
+	ae.String(unix.DEVLINK_ATTR_BUS_NAME, dev.Bus)
+	ae.String(unix.DEVLINK_ATTR_DEV_NAME, dev.Device)
+	data, err := ae.Encode()
 	if err != nil {
 		return nil, err
 	}

--- a/client_linux_integration_test.go
+++ b/client_linux_integration_test.go
@@ -45,14 +45,14 @@ func TestLinuxClientIntegration(t *testing.T) {
 	})
 
 	t.Run("dpipe_tables", func(t *testing.T) {
-		var tables []*devlink.DpipeTable
+		var tables []*devlink.DPIPETable
 		devices, err := c.Devices()
 		if err != nil {
 			t.Fatalf("failed to get devices: %v", err)
 		}
 
 		for _, d := range devices {
-			tt, err := c.DpipeTables(d)
+			tt, err := c.DPIPETables(d)
 			if err != nil {
 				t.Errorf("failed to get DPIPE table from device %v: %v", d, err)
 			}

--- a/client_linux_integration_test.go
+++ b/client_linux_integration_test.go
@@ -43,4 +43,28 @@ func TestLinuxClientIntegration(t *testing.T) {
 			t.Logf("port: %+v", p)
 		}
 	})
+
+	t.Run("dpipe_tables", func(t *testing.T) {
+		var tables []*devlink.DpipeTable
+		devices, err := c.Devices()
+		if err != nil {
+			t.Fatalf("failed to get devices: %v", err)
+		}
+
+		for _, d := range devices {
+			tt, err := c.DpipeTables(d)
+			if err != nil {
+				t.Errorf("failed to get DPIPE table from device %v: %v", d, err)
+			}
+			tables = append(tables, tt...)
+		}
+
+		if len(tables) == 0 {
+			t.Fatalf("failed to retrieve any DPIPE tables from devices")
+		}
+
+		for _, table := range tables {
+			t.Logf("dpipe_table: %+v", table)
+		}
+	})
 }

--- a/client_linux_integration_test.go
+++ b/client_linux_integration_test.go
@@ -59,10 +59,7 @@ func TestLinuxClientIntegration(t *testing.T) {
 			tables = append(tables, tt...)
 		}
 
-		if len(tables) == 0 {
-			t.Fatalf("failed to retrieve any DPIPE tables from devices")
-		}
-
+		// Just print all DPIPE tables that are available.
 		for _, table := range tables {
 			t.Logf("dpipe_table: %+v", table)
 		}

--- a/client_linux_test.go
+++ b/client_linux_test.go
@@ -54,7 +54,7 @@ func TestLinuxClientEmptyResponse(t *testing.T) {
 			name: "dpipe_tables",
 			fn: func(t *testing.T, c *client) {
 				dev := Device{bus, device}
-				tables, err := c.DpipeTables(&dev)
+				tables, err := c.DPIPETables(&dev)
 				if err != nil {
 					t.Fatalf("failed to get DPIPE tables: %v", err)
 				}

--- a/client_linux_test.go
+++ b/client_linux_test.go
@@ -15,6 +15,10 @@ import (
 )
 
 func TestLinuxClientEmptyResponse(t *testing.T) {
+	const (
+		bus    = "pci"
+		device = "0000:01:00.0"
+	)
 	tests := []struct {
 		name string
 		fn   func(t *testing.T, c *client)
@@ -43,6 +47,20 @@ func TestLinuxClientEmptyResponse(t *testing.T) {
 
 				if diff := cmp.Diff(0, len(ports)); diff != "" {
 					t.Fatalf("unexpected number of ports (-want +got):\n%s", diff)
+				}
+			},
+		},
+		{
+			name: "dpipe_tables",
+			fn: func(t *testing.T, c *client) {
+				dev := Device{bus, device}
+				tables, err := c.DpipeTables(&dev)
+				if err != nil {
+					t.Fatalf("failed to get DPIPE tables: %v", err)
+				}
+
+				if diff := cmp.Diff(0, len(tables)); diff != "" {
+					t.Fatalf("unexpected number of DPIPE tables (-want +got):\n%s", diff)
 				}
 			},
 		},

--- a/client_others.go
+++ b/client_others.go
@@ -40,6 +40,6 @@ func (c *client) Ports() ([]*Port, error) {
 }
 
 // PID implements osClient.
-func (c *client) DpipeTables(dev *Device) ([]*DpipeTable, error) {
+func (c *client) DPIPETables(dev *Device) ([]*DPIPETable, error) {
 	return nil, errUnimplemented
 }

--- a/client_others.go
+++ b/client_others.go
@@ -38,3 +38,8 @@ func (c *client) Devices() ([]*Device, error) {
 func (c *client) Ports() ([]*Port, error) {
 	return nil, errUnimplemented
 }
+
+// PID implements osClient.
+func (c *client) DpipeTables(dev *Device) ([]*DpipeTable, error) {
+	return nil, errUnimplemented
+}


### PR DESCRIPTION
Add DpipeTables() function to retrieve a list of all supported DPIPE tables for a specified device.

The following information is collected per DPIPE table:
- devlink bus
- devlink device
- table name
- table size
- table counters_enabled flag

More info about DPIPE:
https://github.com/Mellanox/mlxsw/wiki/Pipeline-Debugging-(DPIPE)